### PR TITLE
Copy directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 
 # Origen local files
 /.bundle
+.project
 /target/.default
 /environment/.default
 /release_note.txt

--- a/lib/origen_app_generators/base.rb
+++ b/lib/origen_app_generators/base.rb
@@ -92,7 +92,11 @@ module OrigenAppGenerators
           end
         elsif file[:type] == :dir || file[:type] == :directory
           if file[:copy]
-            directory(file[:dest] || file[:source])
+            if (file.key? :dest) && (file.key? :source)
+              directory(file[:source], file[:dest])
+            else
+              directory(file[:dest] || file[:source])
+            end
           elsif file[:nokeep]
             empty_directory(file[:dest] || file[:source])
           else


### PR DESCRIPTION
Previously, directory would use files[:dest] as the generic directory name.  This did not take into account the possibility of having a different source directory name and a different destination directory name.

The code
```
     def filelist
        @filelist ||= begin
          list = super  # Always pick up the parent list
          list[:dir] = { source: 'src', dest: 'destination', type: :directory, copy: true }
        end
        list
     end

```

Before, it would give an error that the directory *destination* cannot be found.

Now, it will run.
