### PR TITLE
Make the move NFS mount safe if the output folder is on a different m…

### DIFF
--- a/.github/workflows/regression_tests.yml
+++ b/.github/workflows/regression_tests.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
     - name: Update Env

--- a/.github/workflows/regression_tests.yml
+++ b/.github/workflows/regression_tests.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Install dependencies
       run: bundle install  
     - name: Gem Install Origen 
-      run: gem install origen 
+      run: gem install origen -v 0.59.8 
     - name: Setup Dependencies
       run: origen -v
     - name: Set Origen to debug mode

--- a/bin/boot.rb
+++ b/bin/boot.rb
@@ -12,12 +12,18 @@ $LOAD_PATH.unshift ARGV.shift
 require 'fileutils'
 require 'origen'
 
+# Resolve temp build dir with precedence:
+#   1. ORIGEN_APP_GEN_TMP_DIR env var (highest, linux-like override)
+#   2. site_config :app_gen_tmp_dir
+#   3. hardcoded platform default (legacy behavior)
 # Prevent the bundle from loading by running this outside of the
-if Origen.os.windows?
-  tmp_dir = 'C:/tmp/my_app_generators/new_app'
-else
-  tmp_dir = '/tmp/my_app_generators/new_app'
-end
+default_tmp = Origen.os.windows? ? 'C:/tmp/my_app_generators/new_app'
+                                 : '/tmp/my_app_generators/new_app'
+
+tmp_dir = ENV['ORIGEN_APP_GEN_TMP_DIR'] ||
+          (Origen.site_config.respond_to?(:app_gen_tmp_dir) && Origen.site_config.app_gen_tmp_dir) ||
+          default_tmp
+
 FileUtils.rm_rf tmp_dir if File.exist?(tmp_dir)
 FileUtils.mkdir_p tmp_dir
 

--- a/bin/boot.rb
+++ b/bin/boot.rb
@@ -33,7 +33,12 @@ begin
     OrigenAppGenerators.invoke('my_app')
   end
 ensure
-  FileUtils.mv "#{tmp_dir}/my_app", 'output' if File.exist?("#{tmp_dir}/my_app")
+  src = "#{tmp_dir}/my_app"
+  if File.exist?(src)
+    FileUtils.mkdir_p('output')
+    FileUtils.cp_r(src, 'output')   # cross-device safe
+    FileUtils.rm_rf(src)
+  end
   puts
   puts "Ignore the above, your new app is in: output/my_app"
 end

--- a/templates/app_generators/application/app/lib/module.rb
+++ b/templates/app_generators/application/app/lib/module.rb
@@ -1,6 +1,6 @@
 require 'origen'
 <% if @type == :plugin -%>
-require_relative '../../config/application.rb'
+require_relative '../../config/application'
 <% end -%>
 module <%= @namespace %>
 end

--- a/templates/app_generators/origen_infrastructure/app_generator_plugin/app/lib/module.rb
+++ b/templates/app_generators/origen_infrastructure/app_generator_plugin/app/lib/module.rb
@@ -15,14 +15,12 @@ module <%= @namespace %>
   # array.
   #
   # You can also execute all sets of test inputs by running: 'origen app_gen:test -r'
-  TEST_INPUTS = [
-  ] # END_OF_TEST_INPUTS Don't remove this comment, it is used by the app_gen:new command!
+  TEST_INPUTS = [] # END_OF_TEST_INPUTS Don't remove this comment, it is used by the app_gen:new command!
 
   # As you add new generators to this app they will be entered here, this enables the
   # mechanism to register them with the 'origen new' command.
   # You should generally not modify this by hand, instead use the 'origen app_gen:new'
   # command every time you want to create a new generator, and this will be filled in
   # for you.
-  AVAILABLE = {
-  }
+  AVAILABLE = {}
 end


### PR DESCRIPTION
**Ticket Content**
Severity: Blocker (app generation cannot complete on NFS workspaces)

**Problem Statement**

When running the app generator from a workspace mounted on NFS (e.g., /nfs/local/...), generation fails at the final move step with:

fileutils.rb:529:in `rename': Invalid cross-device link @ rb_file_s_rename -
  (/tmp/my_app_generators/new_app/my_app, output) (Errno::EXDEV)

Root cause: In origen_app_generators-2.2.0/bin/boot.rb, the temp build directory is hardcoded:

# bin/boot.rb (lines 16-20)
if Origen.os.windows?
  tmp_dir = 'C:/tmp/my_app_generators/new_app'
else
  tmp_dir = '/tmp/my_app_generators/new_app'
end

The finished app is then moved to the output directory (relative to CWD):



# bin/boot.rb (line 36)
FileUtils.mv "#{tmp_dir}/my_app", 'output' if File.exist?("#{tmp_dir}/my_app")

The Unix rename(2) syscall can only operate within a single filesystem. Because /tmp (local disk / tmpfs) and output (NFS-mounted CWD) are on different devices, the move raises Errno::EXDEV. Since tmp_dir is a hardcoded literal — not derived from ENV['TMPDIR'] / Dir.tmpdir — users cannot override the temp location to work around the issue.


**Impact**

App generation is completely blocked for any user whose workspace is on a different filesystem than /tmp (the standard setup for NFS-based environments).

No user-facing knob exists to redirect the temp directory.


**Steps to Reproduce**


cd into a workspace on an NFS mount (e.g., /nfs/local/<area>).

Run the app generator (origen new <app> / the amd_app_generators entrypoint).

Observe the Errno::EXDEV failure at the final move step in bin/boot.rb.


**Planned Fix**

- Make the move safe regardless of the location the command is run
- Allow for a user facing environment variable override

